### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,34 +3,27 @@
 	"version": "0.1.1",
 	"description": "Grunt task for running Selenium WebDriver tests on SauceLabs.",
 	"homepage": "https://github.com/burnnat/grunt-sauce-driver",
-	
 	"author": {
 		"name": "Nat Burns",
 		"email": "nbaccount@burnskids.com"
 	},
-	
 	"licenses": [
 		{
 			"type": "MIT",
 			"url": "https://github.com/burnnat/grunt-sauce-driver/blob/master/LICENSE"
 		}
 	],
-	
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/burnnat/grunt-sauce-driver.git"
 	},
-	
 	"bugs": {
 		"url": "https://github.com/burnnat/grunt-sauce-driver/issues"
 	},
-	
 	"engines": {
 		"node": ">=0.8.0"
 	},
-	
 	"main": "drivers.js",
-	
 	"dependencies": {
 		"async": "~0.2.9",
 		"lodash": "~2.3.0",
@@ -38,21 +31,17 @@
 		"sauce-tunnel": "~1.1.0",
 		"wd": "~0.2.3"
 	},
-	
 	"peerDependencies": {
-		"grunt": "~0.4.0"
+		"grunt": ">=0.4.0"
 	},
-	
 	"devDependencies": {
 		"grunt-cli": "~0.1.11",
 		"grunt-contrib-connect": "~0.5.0",
 		"grunt-debug": "~0.0.1"
 	},
-	
 	"scripts": {
 		"test": "node ./node_modules/grunt-cli/bin/grunt test"
 	},
-	
 	"keywords": [
 		"gruntplugin",
 		"grunt",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
